### PR TITLE
Fix an errata in  null operator for numbers

### DIFF
--- a/src/filter/ops/op_val_nums.rs
+++ b/src/filter/ops/op_val_nums.rs
@@ -126,7 +126,7 @@ impl OpValueToOpValType for $ov {
 			("$gt", Value::Number(num)) => $ov::Gt($asfn(num)?),
 			("$gte", Value::Number(num)) => $ov::Gte($asfn(num)?),
 
-			("$null", Value::Number(num)) => $ov::Gte($asfn(num)?),
+			("$null", Value::Bool(v)) => $ov::Null(v),
 
 			(_, value) => return Err(Error::JsonOpValNotSupported{
 						operator: op.to_string(),


### PR DESCRIPTION
This pull-request fixes small errata in null operator for numbers. It allows to check numeric fields for null.